### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -52,6 +52,16 @@
 # cache_ttl = 0
 # stream = true
 
+# [providers.minimax]
+# api_key = "your-minimax-api-key"
+# model = "MiniMax-M2.7"
+# endpoint = "https://api.minimax.io/v1"
+# temperature = 1.0
+# max_tokens = 1000
+# system = "You are a useful assistant"
+# cache_ttl = 0
+# stream = true
+
 # [providers.google]
 # model = "gemini-2.5-flash"
 # api_key = "aaaaaa..."

--- a/src/config/appconfig.rs
+++ b/src/config/appconfig.rs
@@ -213,6 +213,8 @@ pub struct Providers {
     pub google: providers::google::Providers,
     #[serde(default)]
     pub openrouter: providers::openrouter::Providers,
+    #[serde(default)]
+    pub minimax: providers::minimax::Providers,
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/src/config/providers/minimax.rs
+++ b/src/config/providers/minimax.rs
@@ -1,0 +1,55 @@
+use llm::builder::LLMBuilder;
+
+use crate::create_provider;
+use std::convert::From;
+use std::env;
+use log::debug;
+use std::fmt;
+use serde::Deserialize;
+
+const DEFAULT_BASE_URL: &str = "https://api.minimax.io/v1";
+
+create_provider!("minimax" {
+    api_key: String,
+    endpoint: String,
+});
+
+impl TryFrom<&ResolvedProviderConfig> for LLMBuilder {
+    type Error = error::ToLLMBuilderError;
+
+    fn try_from(config: &ResolvedProviderConfig) -> std::result::Result<Self, Self::Error> {
+        let mut builder = LLMBuilder::new()
+            .backend(llm::builder::LLMBackend::OpenAI);
+
+        if let Some(temperature) = config.globals.temperature.as_ref() {
+            builder = builder.temperature(temperature.value);
+        }
+
+        if let Some(system) = config.globals.system.as_ref() {
+            builder = builder.system(&system.value);
+        }
+
+        if let Some(max_tokens) = config.globals.max_tokens.as_ref() {
+            builder = builder.max_tokens(max_tokens.value);
+        }
+
+        let base_url = config.endpoint.as_ref()
+            .map(|e| e.value.clone())
+            .unwrap_or_else(|| DEFAULT_BASE_URL.to_string());
+        builder = builder.base_url(&base_url);
+
+        builder = builder.api_key(
+            config.api_key.as_ref().ok_or(
+                error::ToLLMBuilderError::RequiredConfiguration("minimax", "api_key")
+            )?.value.clone()
+        );
+
+        builder = builder.model(
+            config.globals.model.as_ref().ok_or(
+                error::ToLLMBuilderError::RequiredConfiguration("minimax", "model")
+            )?.value.clone()
+        );
+
+        Ok(builder)
+    }
+}

--- a/src/config/providers/mod.rs
+++ b/src/config/providers/mod.rs
@@ -5,6 +5,7 @@ pub mod anthropic;
 pub mod openai;
 pub mod google;
 pub mod openrouter;
+pub mod minimax;
 pub mod constants;
 
 

--- a/src/config/resolver/base.rs
+++ b/src/config/resolver/base.rs
@@ -70,6 +70,11 @@ impl Base {
 
                 (resolved.globals.clone(), ModelInfo::try_from(&resolved),ResolvedProviderConfig::OpenRouter(resolved))
             },
+            BaseProviderConfigSource::MiniMax(source_config) => {
+                let resolved = resolve_final_config!(minimax, source_config);
+
+                (resolved.globals.clone(), ModelInfo::try_from(&resolved),ResolvedProviderConfig::MiniMax(resolved))
+            },
         };
         Self {
             name,
@@ -97,6 +102,8 @@ impl TryFrom<&Base> for (ModelInfo, LLMBuilder) {
             ResolvedProviderConfig::Google(resolved) =>
                 Ok((ModelInfo::try_from(resolved)?, LLMBuilder::try_from(resolved)?)),
             ResolvedProviderConfig::OpenRouter(resolved) =>
+                Ok((ModelInfo::try_from(resolved)?, LLMBuilder::try_from(resolved)?)),
+            ResolvedProviderConfig::MiniMax(resolved) =>
                 Ok((ModelInfo::try_from(resolved)?, LLMBuilder::try_from(resolved)?)),
         }
     }

--- a/src/config/resolver/display.rs
+++ b/src/config/resolver/display.rs
@@ -73,6 +73,11 @@ impl fmt::Display for ResolvedProviderConfig {
                 writeln!(f, "Configuration:")?;
                 write!(indented(f).with_str("  "), "{conf}")?
             },
+            Self::MiniMax(conf) => {
+                writeln!(f, "MiniMax")?;
+                writeln!(f, "Configuration:")?;
+                write!(indented(f).with_str("  "), "{conf}")?
+            },
         };
 
         Ok(())

--- a/src/config/resolver/mod.rs
+++ b/src/config/resolver/mod.rs
@@ -12,6 +12,7 @@ use crate::config::providers::openai;
 use crate::config::providers::anthropic;
 use crate::config::providers::google;
 use crate::config::providers::openrouter;
+use crate::config::providers::minimax;
 
 pub use variant::Variant;
 pub use base::Base;
@@ -33,6 +34,7 @@ pub enum BaseProviderConfigSource<'a> {
     OpenAI(&'a  openai::Config),
     Google(&'a google::Config),
     OpenRouter(&'a openrouter::Config),
+    MiniMax(&'a minimax::Config),
 }
 
 pub enum VariantProviderConfigSource<'a> {
@@ -41,6 +43,7 @@ pub enum VariantProviderConfigSource<'a> {
     OpenAI(&'a openai::Config, &'a openai::Config),
     Google(&'a google::Config, &'a google::Config),
     OpenRouter(&'a openrouter::Config, &'a openrouter::Config),
+    MiniMax(&'a minimax::Config, &'a minimax::Config),
 }
 
 #[derive(Debug, PartialEq)]
@@ -50,6 +53,7 @@ pub enum ResolvedProviderConfig {
     OpenAI(openai::ResolvedProviderConfig),
     Google(google::ResolvedProviderConfig),
     OpenRouter(openrouter::ResolvedProviderConfig),
+    MiniMax(minimax::ResolvedProviderConfig),
 }
 
 
@@ -204,6 +208,17 @@ impl Resolver {
                     model_resolved_property
                 )
             },
+            "minimax" => {
+                debug!("Resolving {base_name} as MiniMax Base");
+                Base::new(
+                    provider.to_string(),
+                    BaseProviderConfigSource::MiniMax(&appconfig.providers.minimax.config),
+                    fm_properties,
+                    self.overrides.clone(),
+                    global_provider_properties,
+                    model_resolved_property
+                )
+            },
             _ => {
                 Err(error::ResolveError::NotFound(base_name.to_string()))?
             }
@@ -310,6 +325,16 @@ impl Resolver {
                 provider.into(),
                 "openrouter".into(),
                 VariantProviderConfigSource::OpenRouter(conf, &appconfig.providers.openrouter.config),
+                fm_properties,
+                self.overrides.clone(),
+                global_provider_properties,
+                model_resolved_property
+            )
+        } else if let Some(conf) = appconfig.providers.minimax.named.get(provider) {
+            Variant::new(
+                provider.into(),
+                "minimax".into(),
+                VariantProviderConfigSource::MiniMax(conf, &appconfig.providers.minimax.config),
                 fm_properties,
                 self.overrides.clone(),
                 global_provider_properties,
@@ -1604,6 +1629,7 @@ Templ
                         ResolvedProviderConfig::OpenAI(conf) => assert_eq!(conf.globals.model, model),
                         ResolvedProviderConfig::Google(conf) => assert_eq!(conf.globals.model, model),
                         ResolvedProviderConfig::OpenRouter(conf) => assert_eq!(conf.globals.model, model),
+                        ResolvedProviderConfig::MiniMax(conf) => assert_eq!(conf.globals.model, model),
                     }
                 }
                 Ok(ResolvedConfig::Variant(variant)) => {
@@ -1615,6 +1641,7 @@ Templ
                         ResolvedProviderConfig::OpenAI(conf) => assert_eq!(conf.globals.model, model),
                         ResolvedProviderConfig::Google(conf) => assert_eq!(conf.globals.model, model),
                         ResolvedProviderConfig::OpenRouter(conf) => assert_eq!(conf.globals.model, model),
+                        ResolvedProviderConfig::MiniMax(conf) => assert_eq!(conf.globals.model, model),
                     }
                 }
                 Ok(ResolvedConfig::Group(group)) => {
@@ -1634,6 +1661,7 @@ Templ
                                 ResolvedProviderConfig::OpenAI(conf) => assert_eq!(conf.globals.model, model),
                                 ResolvedProviderConfig::Google(conf) => assert_eq!(conf.globals.model, model),
                                 ResolvedProviderConfig::OpenRouter(conf) => assert_eq!(conf.globals.model, model),
+                                ResolvedProviderConfig::MiniMax(conf) => assert_eq!(conf.globals.model, model),
                             }
                         }
                         GroupMember::Variant(variant, _) => {
@@ -1644,6 +1672,7 @@ Templ
                                 ResolvedProviderConfig::OpenAI(conf) => assert_eq!(conf.globals.model, model),
                                 ResolvedProviderConfig::Google(conf) => assert_eq!(conf.globals.model, model),
                                 ResolvedProviderConfig::OpenRouter(conf) => assert_eq!(conf.globals.model, model),
+                                ResolvedProviderConfig::MiniMax(conf) => assert_eq!(conf.globals.model, model),
                             }
                         }
                     }
@@ -1938,6 +1967,7 @@ Templ
                         ResolvedProviderConfig::OpenAI(conf) => assert_eq!(conf.globals.model, model),
                         ResolvedProviderConfig::Google(conf) => assert_eq!(conf.globals.model, model),
                         ResolvedProviderConfig::OpenRouter(conf) => assert_eq!(conf.globals.model, model),
+                        ResolvedProviderConfig::MiniMax(conf) => assert_eq!(conf.globals.model, model),
                     }
                 }
                 Ok(ResolvedConfig::Variant(variant)) => {
@@ -1949,7 +1979,143 @@ Templ
                         ResolvedProviderConfig::OpenAI(conf) => assert_eq!(conf.globals.model, model),
                         ResolvedProviderConfig::Google(conf) => assert_eq!(conf.globals.model, model),
                         ResolvedProviderConfig::OpenRouter(conf) => assert_eq!(conf.globals.model, model),
+                        ResolvedProviderConfig::MiniMax(conf) => assert_eq!(conf.globals.model, model),
                     }
+                }
+                Ok(ResolvedConfig::Group(_)) => {
+                    assert!(matches!(resolve_type, ResolveType::Group));
+                }
+                Err(_) => {
+                    assert!(matches!(resolve_type, ResolveType::Fail));
+                }
+            }
+        });
+    }
+
+    #[rstest]
+    #[case::as_base_with_model(
+r#"
+"#,
+
+r#"
+[providers.minimax]
+api_key = "minimax-key"
+model = "MiniMax-M2.7"
+"#,
+
+r#"
+---
+---
+Templ
+"#,
+        Some("minimax".to_string()),
+        Some(ModelInfo {
+            provider: "minimax".to_string(),
+            model: "MiniMax-M2.7".to_string()
+        }),
+        Some(ResolvedProperty {
+            source: ResolvedPropertySource::Base("minimax".to_string()),
+            value: "MiniMax-M2.7".to_string()
+        }), ResolveType::Base
+    )]
+    #[case::as_base_with_model_in_path(
+r#"
+"#,
+
+r#"
+[providers.minimax]
+api_key = "minimax-key"
+model = "MiniMax-M2.7"
+"#,
+
+r#"
+---
+---
+Templ
+"#,
+        Some("minimax/MiniMax-M2.7-highspeed".to_string()),
+        Some(ModelInfo {
+            provider: "minimax".to_string(),
+            model: "MiniMax-M2.7-highspeed".to_string()
+        }),
+        Some(ResolvedProperty {
+            source: ResolvedPropertySource::Inputs,
+            value: "MiniMax-M2.7-highspeed".to_string()
+        }), ResolveType::Base
+    )]
+    #[case::as_default(
+r#"
+"#,
+
+r#"
+[providers]
+default = "minimax"
+
+[providers.minimax]
+api_key = "minimax-key"
+model = "MiniMax-M2.7"
+"#,
+
+r#"
+---
+---
+Templ
+"#,
+        None,
+        Some(ModelInfo {
+            provider: "minimax".to_string(),
+            model: "MiniMax-M2.7".to_string()
+        }),
+        Some(ResolvedProperty {
+            source: ResolvedPropertySource::Base("minimax".to_string()),
+            value: "MiniMax-M2.7".to_string()
+        }), ResolveType::Base
+    )]
+    pub fn test_minimax(
+        #[case] env: &str,
+        #[case] appconfig: &str,
+        #[case] dotprompt: &str,
+        #[case] requested_model: Option<String>,
+        #[case] modelinfo: Option<ModelInfo>,
+        #[case] model: Option<ResolvedProperty<String>>,
+        #[case] resolve_type: ResolveType
+    ) {
+        let appconfig = AppConfig::try_from(appconfig).unwrap();
+        let dotprompt = DotPrompt::try_from(dotprompt).unwrap();
+
+        let env = if env.trim().is_empty() {
+            Vec::new()
+        } else {
+            env.trim().split("\n").map(|item| {
+                item.split_once("=").map(|(k, v)| (k.trim().to_string(), Some(v.to_string()))).unwrap()
+            }).collect::<Vec<_>>()
+        };
+
+        temp_env::with_vars(env, || {
+            let resolver = Resolver {
+                overrides: None,
+                fm_properties: Some(
+                    ResolvedGlobalProperties::from(
+                        (&GlobalProviderProperties::from(&dotprompt.frontmatter), ResolvedPropertySource::Dotprompt("test".to_string()))
+                    )
+                )
+            };
+            let resolved = resolver.resolve(&appconfig, requested_model);
+            match resolved {
+                Ok(ResolvedConfig::Base(base)) => {
+                    assert!(matches!(resolve_type, ResolveType::Base));
+                    if let Some(modelinfo) = modelinfo {
+                        assert_eq!(base.model_info.unwrap(), modelinfo);
+                    } else {
+                        assert!(base.model_info.is_err())
+                    }
+                    match base.resolved {
+                        ResolvedProviderConfig::MiniMax(conf) => assert_eq!(conf.globals.model, model),
+                        _ => panic!("Expected MiniMax provider"),
+                    }
+                }
+                Ok(ResolvedConfig::Variant(_)) => {
+                    assert!(matches!(resolve_type, ResolveType::Variant));
                 }
                 Ok(ResolvedConfig::Group(_)) => {
                     assert!(matches!(resolve_type, ResolveType::Group));

--- a/src/config/resolver/variant.rs
+++ b/src/config/resolver/variant.rs
@@ -73,6 +73,11 @@ impl Variant {
 
                 (resolved.globals.clone(), ModelInfo::try_from(&resolved), ResolvedProviderConfig::OpenRouter(resolved))
             },
+            VariantProviderConfigSource::MiniMax(variant_config, base_config) => {
+                let resolved = resolve_final_config!(minimax, base_config, variant_config);
+
+                (resolved.globals.clone(), ModelInfo::try_from(&resolved), ResolvedProviderConfig::MiniMax(resolved))
+            },
         };
 
         Self {
@@ -99,6 +104,8 @@ impl TryFrom<&Variant> for (ModelInfo, LLMBuilder) {
             ResolvedProviderConfig::Google(resolved) =>
                 Ok((ModelInfo::try_from(resolved)?, LLMBuilder::try_from(resolved)?)),
             ResolvedProviderConfig::OpenRouter(resolved) =>
+                Ok((ModelInfo::try_from(resolved)?, LLMBuilder::try_from(resolved)?)),
+            ResolvedProviderConfig::MiniMax(resolved) =>
                 Ok((ModelInfo::try_from(resolved)?, LLMBuilder::try_from(resolved)?)),
         }
     }


### PR DESCRIPTION
## Summary

- Add MiniMax as a new LLM provider using the OpenAI-compatible API
- Default base URL: `https://api.minimax.io/v1`
- Supports `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` models
- API key configurable via `PROMPTCMD_MINIMAX_API_KEY` environment variable or config file
- Follows the same provider architecture as existing providers (openai, anthropic, google, openrouter)

## Usage

Configure in `config.toml`:
```toml
[providers.minimax]
api_key = "your-minimax-api-key"
model = "MiniMax-M2.7"
```

Or via environment variable:
```
PROMPTCMD_MINIMAX_API_KEY="your-key" promptctl run myprompt -m minimax/MiniMax-M2.7
```

## API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Test plan

- [x] Unit tests: `cargo test` passes (156 tests, including 3 new MiniMax-specific tests)
- [x] Integration test: MiniMax API responds correctly with `MiniMax-M2.7` model
- [x] `promptctl resolve minimax` shows correct provider configuration
